### PR TITLE
Add note about required GCC version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ CipheyCore builds as a static library, but depends on some of Boost's header-onl
 | Homebrew (OSX) | `brew install boost swig` |
 | Chocolatey (Windows) | `choco install swig` and install boost from boost.org |
 
+:warning: **Note:** This project requires `gcc>=8`. Depending on which platform you are on, you might experience that the default gcc is a lower version. You can check your gcc version by running `gcc -v`.
 ## Building
 
 CipheyCore can be used as a C++ library for use in other C++ projects, or as a python3 module (with reduced functionality and speed). 


### PR DESCRIPTION
Hey! :wave: 
I know that you are still deciding if you are going to deprecate CipheyCore or not, but I think for anyone wanting to set up the project this small note is nice to have : ) 
The `cxx_std_20` flag [requires gcc>=8](https://gcc.gnu.org/projects/cxx-status.html) which is not available on every platform by default.
For instance, the default version of gcc on [Ubuntu 18.04 is 7.4](https://packages.ubuntu.com/search?suite=bionic&keywords=gcc).  
I won't be doing any more work on this, but seeing as I already set things up it does not hurt to have this extra info here : ) 