### PR TITLE
Added #include <utility> xor_single.cpp for fixing compiling error

### DIFF
--- a/src/ciphers/xor_single.cpp
+++ b/src/ciphers/xor_single.cpp
@@ -1,7 +1,7 @@
 #include <ciphey/ciphers.hpp>
 
 #include <iostream>
-
+#include <utility>
 #include <array>
 
 namespace ciphey::xor_single {


### PR DESCRIPTION
@bee-san @Cyclic3 This PR fixes the following error both for C and Python building:
```make
cmake --build . -t ciphey_core_py --config Release

[ 10%] Swig compile /home/athena/toast/CipheyCore/py/python.i for python
[ 10%] Built target ciphey_core_py_swig_compilation
[ 20%] Building CXX object CMakeFiles/ciphey_core.dir/src/ausearch.cpp.o
[ 30%] Building CXX object CMakeFiles/ciphey_core.dir/src/ciphers/caesar.cpp.o
[ 40%] Building CXX object CMakeFiles/ciphey_core.dir/src/ciphers/vigenere.cpp.o
[ 50%] Building CXX object CMakeFiles/ciphey_core.dir/src/ciphers/xor_single.cpp.o
/home/athena/toast/CipheyCore/src/ciphers/xor_single.cpp: In function ‘void ciphey::xor_single::xor_prob_table(ciphey::prob_table&, key_t)’:
/home/athena/toast/CipheyCore/src/ciphers/xor_single.cpp:20:17: error: ‘exchange’ is not a member of ‘std’
   20 |       if (!std::exchange(is_on[i], true)) {
      |                 ^~~~~~~~
/home/athena/toast/CipheyCore/src/ciphers/xor_single.cpp:4:1: note: ‘std::exchange’ is defined in header ‘<utility>’; did you forget to ‘#include <utility>’?
    3 | #include <iostream>
  +++ |+#include <utility>
    4 | 
make[3]: *** [CMakeFiles/ciphey_core.dir/build.make:118: CMakeFiles/ciphey_core.dir/src/ciphers/xor_single.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:87: CMakeFiles/ciphey_core.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:121: CMakeFiles/ciphey_core_py.dir/rule] Error 2
make: *** [Makefile:137: ciphey_core_py] Error 2
```