### PR TITLE
build: use lighter `poety-core`

### DIFF
--- a/py/pyproject.toml.in
+++ b/py/pyproject.toml.in
@@ -12,5 +12,5 @@ python = "^3.5"
 pytest = "^4.6"
 
 [build-system]
-requires = ["poetry>=0.12", "setuptools-cpp"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0", "setuptools-cpp"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
As mentioned in #21, this is using the full `poetry` package as its build backend. But there's a preferred, lightweight `poetry-core` package. From its [readme](https://github.com/python-poetry/poetry-core#why-is-this-required):

> Prior to the release of version `1.1.0`, Poetry was a project management tool that included a PEP 517 build backend. This was inefficient and time consuming when a PEP 517 build was required... This makes PEP 517 builds extremely fast for Poetry managed packages.

This change is especially helpful for distributors (such as Homebrew) to build from source without requiring all of `poetry`.
